### PR TITLE
Add component.json for use with Components/DuoJS.

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,11 @@
+{
+    "name": "rsvp",
+    "repository": "components/rsvp.js",
+    "description": "RSVP.js provides simple tools for organizing asynchronous code.",
+    "version": "3.0.13",
+    "homepage": "http://github.com/components/rsvp.js",
+    "keywords": ["async", "asynchronous", "promise"],
+    "license": "MIT",
+    "main": "rsvp.js",
+    "scripts": ["rsvp.js", "rsvp.min.js", "rsvp.amd.js"]
+}


### PR DESCRIPTION
This allows component.json aware tools like DuoJS make use of this shim without needing special syntax.

Note: Since this repo keeps its version numbers in sync with the main rsvp.js repo, unfortunately DuoJS users will still have to specify an "@master" qualifier until this repo bumps to 3.0.14.
